### PR TITLE
Ignore update when related entity is missing.

### DIFF
--- a/lib/global_registry_bindings/entity/push_relationship_methods.rb
+++ b/lib/global_registry_bindings/entity/push_relationship_methods.rb
@@ -14,21 +14,25 @@ module GlobalRegistry #:nodoc:
         end
 
         def push_relationship_to_global_registry
-          # We can't push relationship if related model is missing, but we may need to delete
+          return unless valid_update?
+          ensure_related_entities_have_global_registry_ids!
+          push_global_registry_relationship_type
+          create_relationship_in_global_registry
+        end
+
+        def valid_update?
+          # We can't update relationship if related model is missing, but we may need to delete
           if relationship.related.nil?
             if relationship.related_id_value.nil? && relationship.id_value
               # Delete relationship if it exists and the related id_value is missing
               delete_relationship_from_global_registry(false)
-              return
-            elsif relationship.related_binding == :entity
-              # Do nothing if related model is missing and related_binding is :entity, :remote binding allows
-              # empty related model
-              return
+              return false
             end
+            # Do nothing if related model is missing and related_binding is :entity, :remote binding allows
+            # empty related model
+            return false if relationship.related_binding == :entity
           end
-          ensure_related_entities_have_global_registry_ids!
-          push_global_registry_relationship_type
-          create_relationship_in_global_registry
+          true
         end
 
         def create_relationship_in_global_registry

--- a/lib/global_registry_bindings/entity/push_relationship_methods.rb
+++ b/lib/global_registry_bindings/entity/push_relationship_methods.rb
@@ -14,10 +14,17 @@ module GlobalRegistry #:nodoc:
         end
 
         def push_relationship_to_global_registry
-          # Delete relationship if it exists and the related id_value is missing
-          if relationship.related.nil? && relationship.related_id_value.nil? && relationship.id_value
-            delete_relationship_from_global_registry(false)
-            return
+          # We can't push relationship if related model is missing, but we may need to delete
+          if relationship.related.nil?
+            if relationship.related_id_value.nil? && relationship.id_value
+              # Delete relationship if it exists and the related id_value is missing
+              delete_relationship_from_global_registry(false)
+              return
+            elsif relationship.related_binding == :entity
+              # Do nothing if related model is missing and related_binding is :entity, :remote binding allows
+              # empty related model
+              return
+            end
           end
           ensure_related_entities_have_global_registry_ids!
           push_global_registry_relationship_type

--- a/lib/global_registry_bindings/options/relationship_class_options.rb
+++ b/lib/global_registry_bindings/options/relationship_class_options.rb
@@ -15,6 +15,7 @@ module GlobalRegistry #:nodoc:
                  :primary_class,
                  :primary_foreign_key,
                  :primary_name,
+                 :related_binding,
                  :related,
                  :related_class,
                  :related_foreign_key,

--- a/lib/global_registry_bindings/options/relationship_instance_options.rb
+++ b/lib/global_registry_bindings/options/relationship_instance_options.rb
@@ -8,6 +8,7 @@ module GlobalRegistry #:nodoc:
                  :push_on,
                  :primary_binding,
                  :primary_foreign_key,
+                 :related_binding,
                  :related_foreign_key,
                  :ensure_type?,
                  :rename_entity_type?,

--- a/lib/global_registry_bindings/options/relationship_options_parser.rb
+++ b/lib/global_registry_bindings/options/relationship_options_parser.rb
@@ -15,7 +15,7 @@ module GlobalRegistry #:nodoc:
             client_integration_id: :id,
             primary_binding: :entity, primary: nil, primary_class: nil, primary_name: nil, primary_foreign_key: nil,
             related: nil, related_class: nil, related_type: nil, related_name: nil, related_foreign_key: nil,
-            related_global_registry_id: nil,
+            related_global_registry_id: nil, related_binding: :entity,
             exclude: %i[id created_at updated_at], include_all_columns: false,
             fields: {}, ensure_type: true, rename_entity_type: true
           }.freeze

--- a/spec/internal/app/models/community.rb
+++ b/spec/internal/app/models/community.rb
@@ -8,6 +8,7 @@ class Community < ApplicationRecord
   global_registry_bindings binding: :relationship,
                            type: :infobase_ministry,
                            id_column: :infobase_gr_id,
+                           related_binding: :remote,
                            related_name: :ministry,
                            related_type: :ministry,
                            related_foreign_key: :infobase_id,

--- a/spec/workers/push_relationship_worker_spec.rb
+++ b/spec/workers/push_relationship_worker_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushRelationshipWorker do
 
         context 'missing related model' do
           let(:person) do
-            create(:person, global_registry_id: '2f0c62f1-5738-4860-88bd-5706fb801d7b', country_of_service_id: 12345)
+            create(:person, global_registry_id: '2f0c62f1-5738-4860-88bd-5706fb801d7b', country_of_service_id: 12_345)
           end
 
           it 'should do nothing' do

--- a/spec/workers/push_relationship_worker_spec.rb
+++ b/spec/workers/push_relationship_worker_spec.rb
@@ -375,6 +375,17 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushRelationshipWorker do
             expect(person.country_of_service_gr_id).to eq '420d2fd1-7a73-41ed-9d8f-5dc79b00a688'
           end
         end
+
+        context 'missing related model' do
+          let(:person) do
+            create(:person, global_registry_id: '2f0c62f1-5738-4860-88bd-5706fb801d7b', country_of_service_id: 12345)
+          end
+
+          it 'should do nothing' do
+            worker.push_relationship_to_global_registry
+            expect(person.country_of_service_gr_id).to be nil
+          end
+        end
       end
 
       describe 'country_of_residence' do


### PR DESCRIPTION
This will silently ignore relationships where the related model is missing, unless it's a :remote binding, where related model is always missing.

It will delete the relationship if related model is missing but we have a Global Registry relationship id value.