### PR TITLE
Add a testing helper to disable adding sidekiq workers during tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,14 +387,14 @@ can use the following test modes:
 
 ```ruby
 require 'global_registry_bindings/testing'
-GlobalRegistry::Bindings::Testing.disable! # disables the test helper, adding workers to a queue. (default). 
+GlobalRegistry::Bindings::Testing.disable_test_helper! # disables the test helper, adding workers to a queue. (default).
 GlobalRegistry::Bindings::Testing.skip_workers!
 ```
 
 Each of the above methods also accepts a block.
 ```ruby
 require 'global_registry_bindings/testing'
-GlobalRegistry::Bindings::Testing.disable!
+GlobalRegistry::Bindings::Testing.disable_test_helper!
 
 # Some tests
 

--- a/README.md
+++ b/README.md
@@ -377,3 +377,34 @@ subsequently changes the value of `:description` and adds an `:authentication` f
 ## Example Models
 
 Example models can be found in the [specs](https://github.com/CruGlobal/global-registry-bindings/tree/master/spec/internal/app/models).
+
+## Testing
+
+Global Registry Bindings includes a testing helper to better help test your project when `gelobal-registry-bindings`
+are included. Since Global Registry Bindings uses sidekiq, it's possible to have these workers executed in your
+projects tests (ex: running sidekiq/testing in [inline!](https://github.com/mperham/sidekiq/wiki/Testing) mode). You
+can use the following test modes:
+
+```ruby
+require 'global_registry_bindings/testing'
+GlobalRegistry::Bindings::Testing.disable! # disables the test helper, adding workers to a queue. (default). 
+GlobalRegistry::Bindings::Testing.skip_workers!
+```
+
+Each of the above methods also accepts a block.
+```ruby
+require 'global_registry_bindings/testing'
+GlobalRegistry::Bindings::Testing.disable!
+
+# Some tests
+
+around(:example) do |example|
+  GlobalRegistry::Bindings::Testing.skip_workers!(&example)
+end
+
+# OR
+
+GlobalRegistry::Bindings::Testing.skip_workers! do
+  # Some other tests
+end
+```

--- a/lib/global_registry_bindings/testing.rb
+++ b/lib/global_registry_bindings/testing.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module GlobalRegistry #:nodoc:
+  module Bindings #:nodoc:
+    class Testing
+      class << self
+        attr_accessor :__test_mode
+
+        def __set_test_mode(mode)
+          if block_given?
+            current_mode = __test_mode
+            begin
+              self.__test_mode = mode
+              yield
+            ensure
+              self.__test_mode = current_mode
+            end
+          else
+            self.__test_mode = mode
+          end
+        end
+
+        def skip_workers!(&block)
+          __set_test_mode(:skip, &block)
+        end
+
+        def disable!(&block)
+          __set_test_mode(:disable, &block)
+        end
+
+        def enabled?
+          __test_mode != :disable
+        end
+
+        def disabled?
+          __test_mode == :disable
+        end
+
+        def skip?
+          __test_mode == :skip
+        end
+      end
+    end
+
+    class Worker
+      class << self
+        alias perform_async_real perform_async
+
+        def perform_async(*args)
+          return if GlobalRegistry::Bindings::Testing.skip?
+          perform_async_real(*args)
+        end
+      end
+    end
+  end
+end
+
+# Default to disabling testing helpers
+GlobalRegistry::Bindings::Testing.disable!

--- a/lib/global_registry_bindings/testing.rb
+++ b/lib/global_registry_bindings/testing.rb
@@ -24,7 +24,7 @@ module GlobalRegistry #:nodoc:
           __set_test_mode(:skip, &block)
         end
 
-        def disable!(&block)
+        def disable_test_helper!(&block)
           __set_test_mode(:disable, &block)
         end
 
@@ -56,4 +56,4 @@ module GlobalRegistry #:nodoc:
 end
 
 # Default to disabling testing helpers
-GlobalRegistry::Bindings::Testing.disable!
+GlobalRegistry::Bindings::Testing.disable_test_helper!

--- a/spec/models/testing_spec.rb
+++ b/spec/models/testing_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe GlobalRegistry::Bindings::Testing do
+  describe 'skip_workers! &block' do
+    around(:example) do |example|
+      GlobalRegistry::Bindings::Testing.skip_workers!(&example)
+    end
+
+    it 'should not enqueue sidekiq jobs' do
+      person = build(:person)
+      expect do
+        person.save
+      end.to change(Sidekiq::Worker.jobs, :size).by(0)
+    end
+
+    context 'disable! &block' do
+      it 'should enqueue sidekiq jobs' do
+        expect(GlobalRegistry::Bindings::Testing.enabled?).to be true
+        GlobalRegistry::Bindings::Testing.disable! do
+          expect(GlobalRegistry::Bindings::Testing.enabled?).to be false
+          expect(GlobalRegistry::Bindings::Testing.disabled?).to be true
+          person = build(:person)
+          expect do
+            person.save
+          end.to change(GlobalRegistry::Bindings::Workers::PushEntityWorker.jobs, :size).by(1).and(
+            change(GlobalRegistry::Bindings::Workers::PullNamespacedPersonMdmIdWorker.jobs, :size).by(1).and(
+              change(GlobalRegistry::Bindings::Workers::PushRelationshipWorker.jobs, :size).by(0).and(
+                change(GlobalRegistry::Bindings::Workers::DeleteEntityWorker.jobs, :size).by(0)
+              )
+            )
+          )
+        end
+        expect(GlobalRegistry::Bindings::Testing.enabled?).to be true
+      end
+    end
+  end
+
+  describe 'skip_workers! enable/disable' do
+    before do
+      GlobalRegistry::Bindings::Testing.skip_workers!
+    end
+    after do
+      GlobalRegistry::Bindings::Testing.disable!
+    end
+
+    it 'should not enqueue sidekiq jobs' do
+      person = build(:person)
+      expect do
+        person.save
+      end.to change(Sidekiq::Worker.jobs, :size).by(0)
+    end
+  end
+end

--- a/spec/models/testing_spec.rb
+++ b/spec/models/testing_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe GlobalRegistry::Bindings::Testing do
       end.to change(Sidekiq::Worker.jobs, :size).by(0)
     end
 
-    context 'disable! &block' do
+    context 'disable_test_helper! &block' do
       it 'should enqueue sidekiq jobs' do
         expect(GlobalRegistry::Bindings::Testing.enabled?).to be true
-        GlobalRegistry::Bindings::Testing.disable! do
+        GlobalRegistry::Bindings::Testing.disable_test_helper! do
           expect(GlobalRegistry::Bindings::Testing.enabled?).to be false
           expect(GlobalRegistry::Bindings::Testing.disabled?).to be true
           person = build(:person)
@@ -42,7 +42,7 @@ RSpec.describe GlobalRegistry::Bindings::Testing do
       GlobalRegistry::Bindings::Testing.skip_workers!
     end
     after do
-      GlobalRegistry::Bindings::Testing.disable!
+      GlobalRegistry::Bindings::Testing.disable_test_helper!
     end
 
     it 'should not enqueue sidekiq jobs' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'factory_girl'
 require 'simplecov'
 
 require 'global_registry_bindings'
+require 'global_registry_bindings/testing'
 
 require 'sidekiq/testing'
 require 'sidekiq_unique_jobs/testing'


### PR DESCRIPTION
MPDX uses sidekiq in inline! mode when testing which causes sidekiq to immediately execute all workers when added to the queue.
`GlobalRegistry::Bindings::Testing.skip_workers!` can be used in testing to disable adding workers to a sidekiq queue.