### PR TITLE
Entity checksums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 coverage/
 tmp/
 gemfiles/*.lock
+spec/internal/db/*.sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
 script:
   - bundle exec rspec
   - bundle exec rubocop -R
-  - cat spec/internal/log/test.log
 gemfile:
   - gemfiles/sidekiq_4.gemfile
   - gemfiles/sidekiq_5.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ cache: bundler
 rvm:
   - 2.3.4
   - 2.4.1
+before_install:
+  - sqlite3 -version
 script:
   - bundle exec rspec
   - bundle exec rubocop -R
+  - cat spec/internal/log/test.log
 gemfile:
   - gemfiles/sidekiq_4.gemfile
   - gemfiles/sidekiq_5.gemfile

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ option is nil or empty. (default: `nil`) **[`:entity`]**
 * `:mdm_timeout`: Only pull mdm information at most once every `:mdm_timeout`. (default: `1.minute`)
 **[`:entity`]**
 
+* `:checksum_column`: Column used to enable checksums and set the name of the column. Checksums are disabled
+when this option is nil or empty. Enabling checksums result in bindings only pushing data on a tracked change.
+(default: `nil`) **[`:entity`]**
+
 * `:if`, `:unless`: Proc or Symbol, called to determine if the change should be sent (enqueue a worker) to Global
 Registry. Proc and Symbol will both receive the model for an entity, and the type and model for a relationship. See
 [Conditional Push](#conditional-push) for examples. **[`:entity`, `:relationship`]**

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ option is nil or empty. (default: `nil`) **[`:entity`]**
 * `:mdm_timeout`: Only pull mdm information at most once every `:mdm_timeout`. (default: `1.minute`)
 **[`:entity`]**
 
-* `:checksum_column`: Column used to enable checksums and set the name of the column. Checksums are disabled
-when this option is nil or empty. Enabling checksums result in bindings only pushing data on a tracked change.
+* `:fingerprint_column`: Column used to enable fingerprints and set the name of the column. fingerprints are disabled
+when this option is nil or empty. Enabling fingerprints result in bindings only pushing data on a tracked change.
 (default: `nil`) **[`:entity`]**
 
 * `:if`, `:unless`: Proc or Symbol, called to determine if the change should be sent (enqueue a worker) to Global

--- a/global-registry-bindings.gemspec
+++ b/global-registry-bindings.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'deepsort', '>= 0.4.1', '< 1.0.0'
 
   s.add_development_dependency 'appraisal'
-  s.add_development_dependency 'combustion', '~> 0.6.0'
+  s.add_development_dependency 'combustion', '~> 1.0'
   s.add_development_dependency 'rails', '>= 4.2.2'
   s.add_development_dependency 'bundler', '~>1.14'
   s.add_development_dependency 'rake', '~> 12'

--- a/global-registry-bindings.gemspec
+++ b/global-registry-bindings.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock', '~> 3.0.0'
   s.add_development_dependency 'factory_girl', '~> 4.8.0'
   s.add_development_dependency 'rubocop', '0.48.1'
-  s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'mock_redis', '~> 0.17.0'
   s.add_development_dependency 'simplecov', '~> 0.14.0'

--- a/global-registry-bindings.gemspec
+++ b/global-registry-bindings.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'global_registry', '~> 1.4', '< 2'
   s.add_runtime_dependency 'sidekiq', '>= 4.0.0', '< 6'
   s.add_runtime_dependency 'sidekiq-unique-jobs', '>= 5.0.0', '< 6'
+  s.add_runtime_dependency 'deepsort', '>= 0.4.1', '< 1.0.0'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'combustion', '~> 0.6.0'

--- a/lib/global_registry_bindings/entity/push_entity_methods.rb
+++ b/lib/global_registry_bindings/entity/push_entity_methods.rb
@@ -81,7 +81,8 @@ module GlobalRegistry #:nodoc:
         end
 
         def entity_checksum
-          @entity_checksum ||= Digest::MD5.hexdigest(Marshal.dump(model.entity_attributes_to_push))
+          @entity_checksum ||=
+            Digest::MD5.hexdigest(Marshal.dump(model.entity_attributes_to_push&.except(:client_updated_at)))
         end
 
         def update_checksum

--- a/lib/global_registry_bindings/entity/push_entity_methods.rb
+++ b/lib/global_registry_bindings/entity/push_entity_methods.rb
@@ -40,7 +40,7 @@ module GlobalRegistry #:nodoc:
                                                                                global_registry_entity.type)
           model.update_column(global_registry_entity.id_column, # rubocop:disable Rails/SkipsModelValidations
                               global_registry_entity.id_value)
-          update_fingerprint if global_registry_entity.fingerprint_column.present?
+          update_fingerprint
         end
 
         # Create or Update a child entity (ex: :email_address is a child of :person)
@@ -59,7 +59,7 @@ module GlobalRegistry #:nodoc:
                                                                                global_registry_entity.parent_type)
           model.update_column(global_registry_entity.id_column, # rubocop:disable Rails/SkipsModelValidations
                               global_registry_entity.id_value)
-          update_fingerprint if global_registry_entity.fingerprint_column.present?
+          update_fingerprint
         end
 
         def dig_global_registry_id_from_entity(entity, type, parent_type = nil)
@@ -86,6 +86,7 @@ module GlobalRegistry #:nodoc:
         end
 
         def update_fingerprint
+          return if global_registry_entity.fingerprint_column.blank?
           model.update_column(global_registry_entity.fingerprint_column, # rubocop:disable Rails/SkipsModelValidations
                               entity_fingerprint)
         end

--- a/lib/global_registry_bindings/options/entity_class_options.rb
+++ b/lib/global_registry_bindings/options/entity_class_options.rb
@@ -8,7 +8,7 @@ module GlobalRegistry #:nodoc:
       class EntityClassOptions
         delegate :id_column,
                  :mdm_id_column,
-                 :checksum_column,
+                 :fingerprint_column,
                  :type,
                  :mdm_timeout,
                  :push_on,

--- a/lib/global_registry_bindings/options/entity_class_options.rb
+++ b/lib/global_registry_bindings/options/entity_class_options.rb
@@ -8,6 +8,7 @@ module GlobalRegistry #:nodoc:
       class EntityClassOptions
         delegate :id_column,
                  :mdm_id_column,
+                 :checksum_column,
                  :type,
                  :mdm_timeout,
                  :push_on,

--- a/lib/global_registry_bindings/options/entity_instance_options.rb
+++ b/lib/global_registry_bindings/options/entity_instance_options.rb
@@ -6,6 +6,7 @@ module GlobalRegistry #:nodoc:
       class EntityInstanceOptions
         delegate :id_column,
                  :mdm_id_column,
+                 :checksum_column,
                  :mdm_timeout,
                  :push_on,
                  :mdm_worker_class_name,

--- a/lib/global_registry_bindings/options/entity_instance_options.rb
+++ b/lib/global_registry_bindings/options/entity_instance_options.rb
@@ -6,7 +6,7 @@ module GlobalRegistry #:nodoc:
       class EntityInstanceOptions
         delegate :id_column,
                  :mdm_id_column,
-                 :checksum_column,
+                 :fingerprint_column,
                  :mdm_timeout,
                  :push_on,
                  :mdm_worker_class_name,

--- a/lib/global_registry_bindings/options/entity_options_parser.rb
+++ b/lib/global_registry_bindings/options/entity_options_parser.rb
@@ -11,7 +11,7 @@ module GlobalRegistry #:nodoc:
         def defaults
           {
             binding: :entity,
-            id_column: :global_registry_id, mdm_id_column: nil, checksum_column: nil,
+            id_column: :global_registry_id, mdm_id_column: nil, fingerprint_column: nil,
             type: @model_class.name.demodulize.underscore.to_sym,
             push_on: %i[create update destroy],
             parent: nil,
@@ -65,7 +65,7 @@ module GlobalRegistry #:nodoc:
           return unless @options[:exclude].is_a? Array
           @options[:exclude] << @options[:id_column]
           @options[:exclude] << @options[:mdm_id_column] if @options[:mdm_id_column].present?
-          @options[:exclude] << @options[:checksum_column] if @options[:checksum_column].present?
+          @options[:exclude] << @options[:fingerprint_column] if @options[:fingerprint_column].present?
 
           parent_id_column = association_foreign_key @options[:parent]
           @options[:exclude] << parent_id_column.to_sym if parent_id_column

--- a/lib/global_registry_bindings/options/entity_options_parser.rb
+++ b/lib/global_registry_bindings/options/entity_options_parser.rb
@@ -11,8 +11,7 @@ module GlobalRegistry #:nodoc:
         def defaults
           {
             binding: :entity,
-            id_column: :global_registry_id,
-            mdm_id_column: nil,
+            id_column: :global_registry_id, mdm_id_column: nil, checksum_column: nil,
             type: @model_class.name.demodulize.underscore.to_sym,
             push_on: %i[create update destroy],
             parent: nil,
@@ -66,6 +65,7 @@ module GlobalRegistry #:nodoc:
           return unless @options[:exclude].is_a? Array
           @options[:exclude] << @options[:id_column]
           @options[:exclude] << @options[:mdm_id_column] if @options[:mdm_id_column].present?
+          @options[:exclude] << @options[:checksum_column] if @options[:checksum_column].present?
 
           parent_id_column = association_foreign_key @options[:parent]
           @options[:exclude] << parent_id_column.to_sym if parent_id_column

--- a/lib/global_registry_bindings/options/entity_options_parser.rb
+++ b/lib/global_registry_bindings/options/entity_options_parser.rb
@@ -8,10 +8,12 @@ module GlobalRegistry #:nodoc:
           @model_class = model_class
         end
 
-        def defaults
+        def defaults # rubocop:disable Metrics/MethodLength
           {
             binding: :entity,
-            id_column: :global_registry_id, mdm_id_column: nil, fingerprint_column: nil,
+            id_column: :global_registry_id,
+            mdm_id_column: nil,
+            fingerprint_column: nil,
             type: @model_class.name.demodulize.underscore.to_sym,
             push_on: %i[create update destroy],
             parent: nil,

--- a/lib/global_registry_bindings/workers/push_entity_worker.rb
+++ b/lib/global_registry_bindings/workers/push_entity_worker.rb
@@ -14,8 +14,6 @@ module GlobalRegistry #:nodoc:
 
         def perform(model_class, id)
           super model_class, id
-          # Don't push entity if Checksum is defined and matches (nothing changed)
-          return if global_registry_entity.checksum_column.present? && checksums_match?
           push_entity_to_global_registry
         rescue ActiveRecord::RecordNotFound # rubocop:disable Lint/HandleExceptions
           # If the record was deleted after the job was created, swallow it

--- a/lib/global_registry_bindings/workers/push_entity_worker.rb
+++ b/lib/global_registry_bindings/workers/push_entity_worker.rb
@@ -14,6 +14,8 @@ module GlobalRegistry #:nodoc:
 
         def perform(model_class, id)
           super model_class, id
+          # Don't push entity if Checksum is defined and matches (nothing changed)
+          return if global_registry_entity.checksum_column.present? && checksums_match?
           push_entity_to_global_registry
         rescue ActiveRecord::RecordNotFound # rubocop:disable Lint/HandleExceptions
           # If the record was deleted after the job was created, swallow it

--- a/spec/acceptance/global_registry_bindings_spec.rb
+++ b/spec/acceptance/global_registry_bindings_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'GlobalRegistry::Bindings' do
       expect(Namespaced::Person.global_registry_entity.exclude)
         .to contain_exactly(:country_of_residence_gr_id, :country_of_residence_id, :country_of_service_gr_id,
                             :country_of_service_id, :created_at, :global_registry_id, :global_registry_mdm_id,
-                            :guid, :id, :updated_at, :global_registry_checksum)
+                            :guid, :id, :updated_at, :global_registry_fingerprint)
       expect(Namespaced::Person.global_registry_entity.fields).to be_a(Hash).and be_empty
       expect(GlobalRegistry::Bindings::Workers::PullNamespacedPersonMdmIdWorker.get_sidekiq_options)
         .to include('unique' => :until_timeout, 'unique_expiration' => 24.hours)

--- a/spec/acceptance/global_registry_bindings_spec.rb
+++ b/spec/acceptance/global_registry_bindings_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'GlobalRegistry::Bindings' do
       expect(Namespaced::Person.global_registry_entity.exclude)
         .to contain_exactly(:country_of_residence_gr_id, :country_of_residence_id, :country_of_service_gr_id,
                             :country_of_service_id, :created_at, :global_registry_id, :global_registry_mdm_id,
-                            :guid, :id, :updated_at)
+                            :guid, :id, :updated_at, :global_registry_checksum)
       expect(Namespaced::Person.global_registry_entity.fields).to be_a(Hash).and be_empty
       expect(GlobalRegistry::Bindings::Workers::PullNamespacedPersonMdmIdWorker.get_sidekiq_options)
         .to include('unique' => :until_timeout, 'unique_expiration' => 24.hours)

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
     guid '98711710-acb5-4a41-ba51-e0fc56644b53'
     global_registry_id nil
     global_registry_mdm_id nil
-    global_registry_checksum nil
+    global_registry_fingerprint nil
     country_of_service_id nil
     country_of_service_gr_id nil
     country_of_residence_id nil

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
     guid '98711710-acb5-4a41-ba51-e0fc56644b53'
     global_registry_id nil
     global_registry_mdm_id nil
+    global_registry_checksum nil
     country_of_service_id nil
     country_of_service_gr_id nil
     country_of_residence_id nil

--- a/spec/internal/app/models/namespaced/person.rb
+++ b/spec/internal/app/models/namespaced/person.rb
@@ -17,7 +17,7 @@ module Namespaced
     global_registry_bindings binding: :entity,
                              mdm_id_column: :global_registry_mdm_id,
                              mdm_timeout: 24.hours,
-                             checksum_column: :global_registry_checksum,
+                             fingerprint_column: :global_registry_fingerprint,
                              include_all_columns: true,
                              exclude: %i[guid country_of_service_gr_id country_of_service_id
                                          country_of_residence_gr_id country_of_residence_id]

--- a/spec/internal/app/models/namespaced/person.rb
+++ b/spec/internal/app/models/namespaced/person.rb
@@ -17,6 +17,7 @@ module Namespaced
     global_registry_bindings binding: :entity,
                              mdm_id_column: :global_registry_mdm_id,
                              mdm_timeout: 24.hours,
+                             checksum_column: :global_registry_checksum,
                              include_all_columns: true,
                              exclude: %i[guid country_of_service_gr_id country_of_service_id
                                          country_of_residence_gr_id country_of_residence_id]

--- a/spec/internal/config/database.yml
+++ b/spec/internal/config/database.yml
@@ -1,4 +1,4 @@
 test:
   adapter:  sqlite3
-  database: ":memory:"
-  verbosity: quiet
+  database: db/test.sqlite
+  timeout: 500

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define(version: 0) do
   create_table :people, force: true do |t|
     t.string :global_registry_id
     t.string :global_registry_mdm_id
+    t.string :global_registry_checksum
     t.string :first_name
     t.string :last_name
     t.string :guid

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define(version: 0) do
-  # enable_extension 'uuid-ossp'
-
   create_table :people, force: true do |t|
     t.string :global_registry_id
     t.string :global_registry_mdm_id

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -4,7 +4,7 @@ ActiveRecord::Schema.define(version: 0) do
   create_table :people, force: true do |t|
     t.string :global_registry_id
     t.string :global_registry_mdm_id
-    t.string :global_registry_checksum
+    t.string :global_registry_fingerprint
     t.string :first_name
     t.string :last_name
     t.string :guid

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,11 @@ require 'active_record'
 ActiveRecord::Migration.verbose = false
 
 require 'combustion'
-Combustion.initialize! :active_record
+Combustion.initialize! :active_record do
+  if config.active_record.sqlite3.respond_to?(:represent_boolean_as_integer)
+    config.active_record.sqlite3.represent_boolean_as_integer = true
+  end
+end
 
 require 'rspec/rails'
 require 'webmock/rspec'

--- a/spec/workers/push_entity_worker_spec.rb
+++ b/spec/workers/push_entity_worker_spec.rb
@@ -127,6 +127,14 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
 
     describe Namespaced::Person do
       let(:worker) { GlobalRegistry::Bindings::Workers::PushEntityWorker.new person }
+      let(:entity_body) do
+        { entity: { person: { first_name: 'Tony', last_name: 'Stark',
+                              client_integration_id: person.id,
+                              client_updated_at: '2001-02-03 00:00:00',
+                              authentication: {
+                                key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
+                              } } } }
+      end
       context 'as create' do
         let(:person) { create(:person, global_registry_fingerprint: 'abc123') }
 
@@ -147,12 +155,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
                                             field_type: 'string' } })
                .to_return(status: 200),
              stub_request(:post, 'https://backend.global-registry.org/entities')
-               .with(body: { entity: { person: { first_name: 'Tony', last_name: 'Stark',
-                                                 client_integration_id: person.id,
-                                                 client_updated_at: '2001-02-03 00:00:00',
-                                                 authentication: {
-                                                   key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
-                                                 } } } })
+               .with(body: entity_body)
                .to_return(body: file_fixture('post_entities_person.json'), status: 200)]
           end
 
@@ -170,12 +173,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
               .with(query: { 'filters[name]' => 'person', 'filters[parent_id]' => nil })
               .to_return(body: file_fixture('get_entity_types_person.json'), status: 200),
              stub_request(:post, 'https://backend.global-registry.org/entities')
-               .with(body: { entity: { person: { first_name: 'Tony', last_name: 'Stark',
-                                                 client_integration_id: person.id,
-                                                 client_updated_at: '2001-02-03 00:00:00',
-                                                 authentication: {
-                                                   key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
-                                                 } } } })
+               .with(body: entity_body)
                .to_return(body: file_fixture('post_entities_person.json'), status: 200)]
           end
 
@@ -197,12 +195,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
                                             field_type: 'string' } })
                .to_return(status: 200),
              stub_request(:post, 'https://backend.global-registry.org/entities')
-               .with(body: { entity: { person: { first_name: 'Tony', last_name: 'Stark',
-                                                 client_integration_id: person.id,
-                                                 client_updated_at: '2001-02-03 00:00:00',
-                                                 authentication: {
-                                                   key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
-                                                 } } } })
+               .with(body: entity_body)
                .to_return(body: file_fixture('post_entities_person.json'), status: 200)]
           end
 
@@ -222,12 +215,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
 
           it 'should skip creating entity_type and push the entity' do
             request = stub_request(:post, 'https://backend.global-registry.org/entities')
-                      .with(body: { entity: { person: { first_name: 'Tony', last_name: 'Stark',
-                                                        client_integration_id: person.id,
-                                                        client_updated_at: '2001-02-03 00:00:00',
-                                                        authentication: {
-                                                          key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
-                                                        } } } })
+                      .with(body: entity_body)
                       .to_return(body: file_fixture('post_entities_person.json'), status: 200)
             worker.push_entity_to_global_registry
             expect(request).to have_been_requested.once
@@ -251,12 +239,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
           it 'should skip creating entity_type and update the entity' do
             request = stub_request(:put,
                                    'https://backend.global-registry.org/entities/f8d20318-2ff2-4a98-a5eb-e9d840508bf1')
-                      .with(body: { entity: { person: { first_name: 'Tony', last_name: 'Stark',
-                                                        client_integration_id: person.id,
-                                                        client_updated_at: '2001-02-03 00:00:00',
-                                                        authentication: {
-                                                          key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
-                                                        } } } })
+                      .with(body: entity_body)
                       .to_return(body: file_fixture('post_entities_person.json'), status: 200)
             worker.push_entity_to_global_registry
             expect(request).to have_been_requested.once
@@ -266,20 +249,10 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             let!(:requests) do
               [stub_request(:put,
                             'https://backend.global-registry.org/entities/f8d20318-2ff2-4a98-a5eb-e9d840508bf1')
-                .with(body: { entity: { person: { first_name: 'Tony', last_name: 'Stark',
-                                                  client_integration_id: person.id,
-                                                  client_updated_at: '2001-02-03 00:00:00',
-                                                  authentication: {
-                                                    key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
-                                                  } } } })
+                .with(body: entity_body)
                 .to_return(status: 404),
                stub_request(:post, 'https://backend.global-registry.org/entities')
-                 .with(body: { entity: { person: { first_name: 'Tony', last_name: 'Stark',
-                                                   client_integration_id: person.id,
-                                                   client_updated_at: '2001-02-03 00:00:00',
-                                                   authentication: {
-                                                     key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
-                                                   } } } })
+                 .with(body: entity_body)
                  .to_return(body: file_fixture('post_entities_person.json'), status: 200)]
             end
 
@@ -295,12 +268,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             it 'should do nothing' do
               request = stub_request(:put,
                                      'https://backend.global-registry.org/entities/f8d20318-2ff2-4a98-a5eb-e9d840508bf1')
-                        .with(body: { entity: { person: { first_name: 'Tony', last_name: 'Stark',
-                                                          client_integration_id: person.id,
-                                                          client_updated_at: '2001-02-03 00:00:00',
-                                                          authentication: {
-                                                            key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
-                                                          } } } })
+                        .with(body: entity_body)
                         .to_return(body: file_fixture('post_entities_person.json'), status: 200)
               person.global_registry_fingerprint = '4c671c203b5dd19cdc1920ba5434cf64'
               worker.push_entity_to_global_registry

--- a/spec/workers/push_entity_worker_spec.rb
+++ b/spec/workers/push_entity_worker_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             worker.push_entity_to_global_registry
             requests.each { |r| expect(r).to have_been_requested.once }
             expect(person.global_registry_id).to eq '22527d88-3cba-11e7-b876-129bd0521531'
-            expect(person.global_registry_checksum).to eq '64b7a7f6daebe8d8e8234651ae4c51d4'
+            expect(person.global_registry_checksum).to eq '4c671c203b5dd19cdc1920ba5434cf64'
           end
         end
 
@@ -183,7 +183,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             worker.push_entity_to_global_registry
             requests.each { |r| expect(r).to have_been_requested.once }
             expect(person.global_registry_id).to eq '22527d88-3cba-11e7-b876-129bd0521531'
-            expect(person.global_registry_checksum).to eq '64b7a7f6daebe8d8e8234651ae4c51d4'
+            expect(person.global_registry_checksum).to eq '4c671c203b5dd19cdc1920ba5434cf64'
           end
         end
 
@@ -210,7 +210,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             worker.push_entity_to_global_registry
             requests.each { |r| expect(r).to have_been_requested.once }
             expect(person.global_registry_id).to eq '22527d88-3cba-11e7-b876-129bd0521531'
-            expect(person.global_registry_checksum).to eq '64b7a7f6daebe8d8e8234651ae4c51d4'
+            expect(person.global_registry_checksum).to eq '4c671c203b5dd19cdc1920ba5434cf64'
           end
         end
 
@@ -232,7 +232,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             worker.push_entity_to_global_registry
             expect(request).to have_been_requested.once
             expect(person.global_registry_id).to eq '22527d88-3cba-11e7-b876-129bd0521531'
-            expect(person.global_registry_checksum).to eq '64b7a7f6daebe8d8e8234651ae4c51d4'
+            expect(person.global_registry_checksum).to eq '4c671c203b5dd19cdc1920ba5434cf64'
           end
         end
       end
@@ -287,7 +287,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
               worker.push_entity_to_global_registry
               requests.each { |r| expect(r).to have_been_requested.once }
               expect(person.global_registry_id).to eq '22527d88-3cba-11e7-b876-129bd0521531'
-              expect(person.global_registry_checksum).to eq '64b7a7f6daebe8d8e8234651ae4c51d4'
+              expect(person.global_registry_checksum).to eq '4c671c203b5dd19cdc1920ba5434cf64'
             end
           end
 
@@ -302,7 +302,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
                                                             key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
                                                           } } } })
                         .to_return(body: file_fixture('post_entities_person.json'), status: 200)
-              person.global_registry_checksum = '64b7a7f6daebe8d8e8234651ae4c51d4'
+              person.global_registry_checksum = '4c671c203b5dd19cdc1920ba5434cf64'
               worker.push_entity_to_global_registry
               expect(request).not_to have_been_requested
             end

--- a/spec/workers/push_entity_worker_spec.rb
+++ b/spec/workers/push_entity_worker_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
         end
       end
 
-      context 'with valid id and checksum' do
+      context 'with valid id and fingerprint' do
         it 'should call #push_entity_to_global_registry' do
           expect(Namespaced::Person).to receive(:find).with(person.id).and_return(person)
 
@@ -128,7 +128,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
     describe Namespaced::Person do
       let(:worker) { GlobalRegistry::Bindings::Workers::PushEntityWorker.new person }
       context 'as create' do
-        let(:person) { create(:person, global_registry_checksum: 'abc123') }
+        let(:person) { create(:person, global_registry_fingerprint: 'abc123') }
 
         context '\'person\' entity_type does not exist' do
           let!(:requests) do
@@ -160,7 +160,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             worker.push_entity_to_global_registry
             requests.each { |r| expect(r).to have_been_requested.once }
             expect(person.global_registry_id).to eq '22527d88-3cba-11e7-b876-129bd0521531'
-            expect(person.global_registry_checksum).to eq '4c671c203b5dd19cdc1920ba5434cf64'
+            expect(person.global_registry_fingerprint).to eq '4c671c203b5dd19cdc1920ba5434cf64'
           end
         end
 
@@ -183,7 +183,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             worker.push_entity_to_global_registry
             requests.each { |r| expect(r).to have_been_requested.once }
             expect(person.global_registry_id).to eq '22527d88-3cba-11e7-b876-129bd0521531'
-            expect(person.global_registry_checksum).to eq '4c671c203b5dd19cdc1920ba5434cf64'
+            expect(person.global_registry_fingerprint).to eq '4c671c203b5dd19cdc1920ba5434cf64'
           end
         end
 
@@ -210,7 +210,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             worker.push_entity_to_global_registry
             requests.each { |r| expect(r).to have_been_requested.once }
             expect(person.global_registry_id).to eq '22527d88-3cba-11e7-b876-129bd0521531'
-            expect(person.global_registry_checksum).to eq '4c671c203b5dd19cdc1920ba5434cf64'
+            expect(person.global_registry_fingerprint).to eq '4c671c203b5dd19cdc1920ba5434cf64'
           end
         end
 
@@ -232,7 +232,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             worker.push_entity_to_global_registry
             expect(request).to have_been_requested.once
             expect(person.global_registry_id).to eq '22527d88-3cba-11e7-b876-129bd0521531'
-            expect(person.global_registry_checksum).to eq '4c671c203b5dd19cdc1920ba5434cf64'
+            expect(person.global_registry_fingerprint).to eq '4c671c203b5dd19cdc1920ba5434cf64'
           end
         end
       end
@@ -240,7 +240,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
       context 'as an update' do
         let(:person) do
           create(:person, global_registry_id: 'f8d20318-2ff2-4a98-a5eb-e9d840508bf1',
-                          global_registry_checksum: 'abc123')
+                          global_registry_fingerprint: 'abc123')
         end
         context '\'person\' entity_type is cached' do
           before :each do
@@ -287,11 +287,11 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
               worker.push_entity_to_global_registry
               requests.each { |r| expect(r).to have_been_requested.once }
               expect(person.global_registry_id).to eq '22527d88-3cba-11e7-b876-129bd0521531'
-              expect(person.global_registry_checksum).to eq '4c671c203b5dd19cdc1920ba5434cf64'
+              expect(person.global_registry_fingerprint).to eq '4c671c203b5dd19cdc1920ba5434cf64'
             end
           end
 
-          context 'checksums match' do
+          context 'fingerprints match' do
             it 'should do nothing' do
               request = stub_request(:put,
                                      'https://backend.global-registry.org/entities/f8d20318-2ff2-4a98-a5eb-e9d840508bf1')
@@ -302,7 +302,7 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
                                                             key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
                                                           } } } })
                         .to_return(body: file_fixture('post_entities_person.json'), status: 200)
-              person.global_registry_checksum = '4c671c203b5dd19cdc1920ba5434cf64'
+              person.global_registry_fingerprint = '4c671c203b5dd19cdc1920ba5434cf64'
               worker.push_entity_to_global_registry
               expect(request).not_to have_been_requested
             end

--- a/spec/workers/push_entity_worker_spec.rb
+++ b/spec/workers/push_entity_worker_spec.rb
@@ -295,13 +295,13 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PushEntityWorker do
             it 'should do nothing' do
               request = stub_request(:put,
                                      'https://backend.global-registry.org/entities/f8d20318-2ff2-4a98-a5eb-e9d840508bf1')
-                          .with(body: { entity: { person: { first_name: 'Tony', last_name: 'Stark',
-                                                            client_integration_id: person.id,
-                                                            client_updated_at: '2001-02-03 00:00:00',
-                                                            authentication: {
-                                                              key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
-                                                            } } } })
-                          .to_return(body: file_fixture('post_entities_person.json'), status: 200)
+                        .with(body: { entity: { person: { first_name: 'Tony', last_name: 'Stark',
+                                                          client_integration_id: person.id,
+                                                          client_updated_at: '2001-02-03 00:00:00',
+                                                          authentication: {
+                                                            key_guid: '98711710-acb5-4a41-ba51-e0fc56644b53'
+                                                          } } } })
+                        .to_return(body: file_fixture('post_entities_person.json'), status: 200)
               person.global_registry_checksum = '64b7a7f6daebe8d8e8234651ae4c51d4'
               worker.push_entity_to_global_registry
               expect(request).not_to have_been_requested


### PR DESCRIPTION
This PR adds an optional fingerprint field to global registry bindings.
When set to a symbol, it will check the corresponding model attribute to see if a fingerprint exists already. If it exists and it equals the newly computed fingerprint, it will skip pushing the entity to Global Registry. This most likely means something changed on the model that isn't tracked in GR, so no need to push. Models missing a global_registry_id will always be pushed.
