### PR TITLE
Prevent mdm_worker_class method from unnecessarily creating classes

### DIFF
--- a/global-registry-bindings.gemspec
+++ b/global-registry-bindings.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock', '~> 3.0.0'
   s.add_development_dependency 'factory_girl', '~> 4.8.0'
   s.add_development_dependency 'rubocop', '0.48.1'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'mock_redis', '~> 0.17.0'
   s.add_development_dependency 'simplecov', '~> 0.14.0'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
Hi 👋 

I'm a contractor working on MissionHub and I was noticing warnings in our test output and rails console.  I tracked it back to this gem, and spent a little bit of time seeing if I could resolve the issue.

This is the warning we are seeing:

```
➜  missionhub-api git:(MHP-2203) bin/rspec ./spec/acceptance/
/Users/will/.gem/ruby/2.5.3/gems/global-registry-bindings-0.2.0/lib/global_registry_bindings/workers/pull_mdm_id_worker.rb:12: warning: already initialized constant GlobalRegistry::Bindings::Workers::PullV4PersonMdmIdWorker
/Users/will/.gem/ruby/2.5.3/gems/global-registry-bindings-0.2.0/lib/global_registry_bindings/workers/pull_mdm_id_worker.rb:12: warning: previous definition of PullV4PersonMdmIdWorker was here
Running via Spring preloader in process 55816
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 60796
...
```

This seems to fix the problem for our application.  I've included a proper description of what the change entails in the commit message.  I thought I would open a PR and see if it could be merged in.

Thanks!