### PR TITLE
Handle 404 on update dependent entity

### DIFF
--- a/lib/global_registry_bindings/entity/push_entity_methods.rb
+++ b/lib/global_registry_bindings/entity/push_entity_methods.rb
@@ -22,15 +22,15 @@ module GlobalRegistry #:nodoc:
           else
             create_entity_in_global_registry
           end
-        rescue RestClient::ResourceNotFound
-          global_registry_entity.id_value = nil
-          push_entity_to_global_registry
         end
 
         def update_entity_in_global_registry
           entity_attributes = { global_registry_entity.type => model.entity_attributes_to_push }
           GlobalRegistry::Entity.put(global_registry_entity.id_value, entity: entity_attributes)
           update_fingerprint
+        rescue RestClient::ResourceNotFound
+          global_registry_entity.id_value = nil
+          create_entity_in_global_registry
         end
 
         def create_entity_in_global_registry

--- a/lib/global_registry_bindings/version.rb
+++ b/lib/global_registry_bindings/version.rb
@@ -2,6 +2,6 @@
 
 module GlobalRegistry #:nodoc:
   module Bindings #:nodoc:
-    VERSION = '0.3.2'
+    VERSION = '0.3.3'
   end
 end


### PR DESCRIPTION
If the PUT inside `create_dependent_entity_in_global_registry` returned a
404 then the GR bindings would enter into an infinite loop. This caused
containers to eventually run out of memory.

This update changes the bindings to simply raise an error in this case.

It wasn't clear to me if a corrective step was possible in this situation (like how the `update_entity_in_global_registry` method attempts to create the entity if a 404 is received) because I'm not familiar enough with the context.

A stack error trace for this issue can be seen at https://rollbar.com/Cru/MissionHub-API/items/907/