### PR TITLE
Skip no-op MDM id writes

### DIFF
--- a/lib/global_registry_bindings/entity/mdm_methods.rb
+++ b/lib/global_registry_bindings/entity/mdm_methods.rb
@@ -20,7 +20,12 @@ module GlobalRegistry # :nodoc:
               "GR entity #{global_registry_entity.id_value} for #{model.class.name}(#{model.id}) has no mdm id; " \
               "will retry"
           end
-          model.update_column(global_registry_entity.mdm_id_column, mdm_entity_id) # rubocop:disable Rails/SkipsModelValidations
+          mdm_id_column = global_registry_entity.mdm_id_column
+          # Skip the write when the MDM id is unchanged. update_column always issues an
+          # UPDATE, so re-pulling an unchanged MDM id churns the row (and downstream
+          # replication/WAL consumers) for no reason.
+          return if model.send(mdm_id_column) == mdm_entity_id
+          model.update_column(mdm_id_column, mdm_entity_id) # rubocop:disable Rails/SkipsModelValidations
         end
 
         def dig_global_registry_mdm_id_from_entity(entity, type)

--- a/spec/workers/pull_mdm_id_worker_spec.rb
+++ b/spec/workers/pull_mdm_id_worker_spec.rb
@@ -98,6 +98,44 @@ RSpec.describe GlobalRegistry::Bindings::Workers::PullMdmIdWorker do
           end.not_to raise_error
         end
       end
+
+      context "mdm id is unchanged" do
+        let(:person) do
+          create(:person, global_registry_id: "22527d88-3cba-11e7-b876-129bd0521531",
+            global_registry_mdm_id: "c81340b2-7e57-4978-b6b9-396f21bb0bb2")
+        end
+        let!(:request) do
+          stub_request(:get, "https://backend.global-registry.org/entities/22527d88-3cba-11e7-b876-129bd0521531")
+            .with(query: {"filters[owned_by]" => "mdm"})
+            .to_return(body: file_fixture("get_entities_person_mdm.json"), status: 200)
+        end
+
+        it "does not write to the database" do
+          expect(person).not_to receive(:update_column)
+          expect { worker.pull_mdm_id_from_global_registry }.not_to raise_error
+          expect(person.global_registry_mdm_id).to eq "c81340b2-7e57-4978-b6b9-396f21bb0bb2"
+        end
+      end
+
+      context "mdm id has changed" do
+        let(:person) do
+          create(:person, global_registry_id: "22527d88-3cba-11e7-b876-129bd0521531",
+            global_registry_mdm_id: "00000000-0000-0000-0000-000000000000")
+        end
+        let!(:request) do
+          stub_request(:get, "https://backend.global-registry.org/entities/22527d88-3cba-11e7-b876-129bd0521531")
+            .with(query: {"filters[owned_by]" => "mdm"})
+            .to_return(body: file_fixture("get_entities_person_mdm.json"), status: 200)
+        end
+
+        it "writes the new mdm id" do
+          expect(person).to receive(:update_column)
+            .with(Namespaced::Person.global_registry_entity.mdm_id_column,
+              "c81340b2-7e57-4978-b6b9-396f21bb0bb2").and_call_original
+          worker.pull_mdm_id_from_global_registry
+          expect(person.reload.global_registry_mdm_id).to eq "c81340b2-7e57-4978-b6b9-396f21bb0bb2"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This prevents a lot of no-op UPDATE statements to the mpdx person table. These no-ops are still recorded in the WAL, and so they propagate to fivetran, which increases both fivetran and bigquery costs.